### PR TITLE
setup.py: Use setuptools-markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ setup(
     author_email =  'jon.brandvein@gmail.com',
     license =       'MIT License',
     description =   'A library for defining struct-like classes',
+    setup_requires = ['setuptools-markdown'],
+    long_description_markdown_filename = 'README.md',
     
     classifiers = [
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Use [setuptools-markdown](https://pypi.python.org/pypi/setuptools-markdown)
to use README.rst for PyPI long description.
